### PR TITLE
Allow delegate to be set on BLESessionManager initialiser.

### DIFF
--- a/AirShare/BLESessionManager.m
+++ b/AirShare/BLESessionManager.m
@@ -35,6 +35,7 @@
         _identifiersToPeers = [NSMutableDictionary dictionary];
         _identifiersUndergoingPeerDiscovery = [NSMutableSet set];
         _receiverForIdentifier = [NSMutableDictionary dictionary];
+        [self setDelegate: delegate];
         [self registerTransports];
     }
     return self;


### PR DESCRIPTION
Fixes issue where delegate argument isn’t set from initialiser.
